### PR TITLE
feat(ui): add responsive Navbar, Card, and Footer components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Jost } from "next/font/google";
+import { Jost } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 const jost = Jost({
   variable: "--font-jost",
@@ -19,10 +21,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${jost.className} antialiased`}
-      >
+      <body className={`${jost.className} antialiased bg-[--color-light-100] text-[--color-dark-900]`}>
+        <Navbar />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+export interface CardProps {
+  title: string;
+  description?: string;
+  subtitle?: string;
+  price?: number | string;
+  imageSrc: string;
+  imageAlt?: string;
+  badgeText?: string;
+  href?: string;
+  className?: string;
+  footerNote?: string;
+}
+
+export default function Card({
+  title,
+  description,
+  subtitle,
+  price,
+  imageSrc,
+  imageAlt = "",
+  badgeText,
+  href,
+  className,
+  footerNote,
+}: CardProps) {
+  const content = (
+    <div
+      className={`group overflow-hidden rounded-xl bg-[--color-light-100] shadow-sm ring-1 ring-[--color-light-300] hover:shadow-lg transition-shadow ${className || ""}`}
+    >
+      <div className="relative aspect-[4/3] w-full">
+        <Image
+          src={imageSrc}
+          alt={imageAlt || title}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover"
+          priority={false}
+        />
+        {badgeText ? (
+          <span className="absolute left-3 top-3 rounded-full bg-[--color-light-100] px-3 py-1 text-[--color-red] text-[length:var(--text-caption)] font-[var(--text-caption--font-weight)] shadow">
+            {badgeText}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="text-[--color-dark-900] text-[length:var(--text-heading-3)] leading-[var(--text-heading-3--line-height)] font-[var(--text-heading-3--font-weight)] line-clamp-1">
+            {title}
+          </h3>
+          {price !== undefined ? (
+            <span className="shrink-0 text-[--color-dark-900] text-[length:var(--text-body)] font-[var(--text-body-medium--font-weight)]">
+              {typeof price === "number" ? `$${price.toFixed(2)}` : price}
+            </span>
+          ) : null}
+        </div>
+
+        {subtitle ? (
+          <p className="mt-1 text-[--color-dark-700] text-[length:var(--text-body)] leading-[var(--text-body--line-height)]">
+            {subtitle}
+          </p>
+        ) : null}
+
+        {description ? (
+          <p className="mt-1 text-[--color-dark-700] text-[length:var(--text-caption)] leading-[var(--text-caption--line-height)] line-clamp-2">
+            {description}
+          </p>
+        ) : null}
+
+        {footerNote ? (
+          <p className="mt-2 text-[--color-dark-500] text-[length:var(--text-footnote)] leading-[var(--text-footnote--line-height)]">
+            {footerNote}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900] rounded-xl">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+export interface FooterProps {
+  className?: string;
+  year?: number;
+}
+
+export default function Footer({ className, year = new Date().getFullYear() }: FooterProps) {
+  const columns: { title: string; links: string[] }[] = [
+    { title: "Featured", links: ["Air Force 1", "Huarache", "Air Max 90", "Air Max 95"] },
+    { title: "Shoes", links: ["All Shoes", "Custom Shoes", "Jordan Shoes", "Running Shoes"] },
+    { title: "Clothing", links: ["All Clothing", "Modest Wear", "Hoodies & Pullovers", "Shirts & Tops"] },
+    { title: "Kids'", links: ["Infant & Toddler Shoes", "Kids' Shoes", "Kids' Jordan Shoes", "Kids' Basketball Shoes"] },
+  ];
+
+  const socials = [
+    { src: "/x.svg", alt: "X", href: "#" },
+    { src: "/facebook.svg", alt: "Facebook", href: "#" },
+    { src: "/instagram.svg", alt: "Instagram", href: "#" },
+  ];
+
+  return (
+    <footer
+      aria-label="Footer"
+      className={`mt-16 w-full bg-[--color-dark-900] text-[--color-light-100] ${className || ""}`}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-12 md:gap-8">
+          <div className="md:col-span-3">
+            <Link href="#" aria-label="Home" className="inline-flex">
+              <Image src="/logo.svg" alt="Nike" width={40} height={40} />
+            </Link>
+          </div>
+
+          <div className="md:col-span-8 grid grid-cols-2 sm:grid-cols-2 md:grid-cols-4 gap-8">
+            {columns.map((col) => (
+              <nav key={col.title} aria-label={col.title}>
+                <h4 className="text-[length:var(--text-heading-3)] font-[var(--text-heading-3--font-weight)]">
+                  {col.title}
+                </h4>
+                <ul className="mt-4 space-y-3">
+                  {col.links.map((l) => (
+                    <li key={l}>
+                      <Link
+                        href="#"
+                        className="text-[--color-dark-500] hover:text-[--color-light-100] text-[length:var(--text-body)] leading-[var(--text-body--line-height)]"
+                      >
+                        {l}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            ))}
+          </div>
+
+          <div className="md:col-span-1 flex md:justify-end">
+            <div className="flex items-center gap-4">
+              {socials.map((s) => (
+                <Link
+                  key={s.alt}
+                  href={s.href}
+                  aria-label={s.alt}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900] hover:opacity-90"
+                >
+                  <Image src={s.src} alt={s.alt} width={18} height={18} />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-10 border-t border-[--color-dark-700]/40 pt-6 text-[--color-dark-500] text-[length:var(--text-footnote)] leading-[var(--text-footnote--line-height)]">
+          <p>&copy; {year} Nike. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+export interface NavbarProps {
+  cartCount?: number;
+  className?: string;
+}
+
+export default function Navbar({ cartCount = 0, className }: NavbarProps) {
+  const [open, setOpen] = useState(false);
+
+  const links = [
+    { label: "Men", href: "#" },
+    { label: "Women", href: "#" },
+    { label: "Kids", href: "#" },
+    { label: "Collections", href: "#" },
+    { label: "Contact", href: "#" },
+  ];
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Primary"
+      className={`sticky top-0 z-40 w-full bg-[--color-light-100] border-b border-[--color-light-300] ${className || ""}`}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="#" aria-label="Home" className="flex items-center">
+              <Image src="/logo.svg" alt="Nike" width={28} height={28} priority />
+            </Link>
+
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md p-2 text-[--color-dark-900] hover:bg-[--color-light-200] focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900] md:hidden"
+              aria-controls="mobile-menu"
+              aria-expanded={open}
+              aria-label={open ? "Close menu" : "Open menu"}
+              onClick={() => setOpen((v) => !v)}
+            >
+              <span className="sr-only">Toggle menu</span>
+              <svg
+                className="h-6 w-6"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+              >
+                {open ? (
+                  <path
+                    d="M6 6l12 12M18 6L6 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                ) : (
+                  <path
+                    d="M4 6h16M4 12h16M4 18h16"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                )}
+              </svg>
+            </button>
+          </div>
+
+          <ul className="hidden md:flex items-center gap-8">
+            {links.map((l) => (
+              <li key={l.label}>
+                <Link
+                  href={l.href}
+                  className="text-[--color-dark-900] text-[length:var(--text-body)] leading-[var(--text-body--line-height)] font-[var(--text-body-medium--font-weight)] hover:text-[--color-dark-700] focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900] rounded"
+                >
+                  {l.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          <div className="hidden md:flex items-center gap-6">
+            <button
+              className="text-[--color-dark-900] hover:text-[--color-dark-700] text-[length:var(--text-body)] leading-[var(--text-body--line-height)]"
+              aria-label="Search"
+            >
+              Search
+            </button>
+            <Link
+              href="#"
+              className="text-[--color-dark-900] font-[var(--text-body-medium--font-weight)]"
+              aria-label="View cart"
+            >
+              My Cart ({cartCount})
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div
+        id="mobile-menu"
+        className={`md:hidden ${open ? "block" : "hidden"} border-t border-[--color-light-300]`}
+      >
+        <div className="space-y-1 px-4 pb-4 pt-2">
+          {links.map((l) => (
+            <Link
+              key={l.label}
+              href={l.href}
+              className="block rounded-md px-3 py-2 text-[--color-dark-900] hover:bg-[--color-light-200] focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900]"
+            >
+              {l.label}
+            </Link>
+          ))}
+          <div className="mt-2 flex items-center justify-between rounded-md bg-[--color-light-200] px-3 py-2">
+            <span className="text-[--color-dark-900]">Search</span>
+            <Link href="#" className="text-[--color-dark-900]">
+              Cart ({cartCount})
+            </Link>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
# feat(ui): add responsive Navbar, Card, and Footer components

## Summary
Implements three new React components for the Nike e-commerce app:
- **Navbar**: Responsive navigation with mobile hamburger menu, Nike logo, and cart indicator
- **Card**: Reusable product card component with image, title, price, badges, and optional linking
- **Footer**: Multi-column footer with navigation links, social icons, and copyright

All components use the design system tokens from `globals.css` via Tailwind CSS arbitrary values (e.g., `text-[--color-dark-900]`, `text-[length:var(--text-body)]`) and leverage assets from `/public` folder. Components are wired into the global layout for app-wide usage.

## Review & Testing Checklist for Human

**⚠️ High Priority - Visual Verification Required**
- [ ] **Run `npm run dev` and verify all components render correctly in browser** - the CSS variable + Tailwind syntax approach needs visual confirmation
- [ ] **Test mobile responsiveness** - hamburger menu toggles properly, grid layouts stack correctly on small screens  
- [ ] **Verify asset loading** - Nike logo, social icons (X, Facebook, Instagram) load from `/public` folder
- [ ] **Check accessibility** - tab navigation works, ARIA labels are announced correctly, focus states visible

### Test Plan
1. Start dev server and navigate to homepage
2. Test desktop: verify navbar links, footer columns, card layout
3. Test mobile: toggle hamburger menu, verify responsive grid behavior
4. Test keyboard navigation and screen reader compatibility

### Notes
- All navigation links currently point to "#" as placeholder URLs
- Components use theme tokens from `globals.css` but the CSS variable syntax in Tailwind is non-standard and needs verification
- Build fails due to unrelated database configuration issue, but lint passes

**Link to Devin run**: https://app.devin.ai/sessions/5fe8587b9773417d8512c459dc8d2c93  
**Requested by**: @kennethbernstrom